### PR TITLE
Check that the platform is linux before downloading sky_snapshot binary

### DIFF
--- a/lib/src/artifacts.dart
+++ b/lib/src/artifacts.dart
@@ -88,6 +88,8 @@ class ArtifactStore {
     File cachedFile = new File(path.join(cacheDir.path, name));
     if (!await cachedFile.exists()) {
       _logging.info('Downloading ${name} from the cloud, one moment please...');
+      if (!Platform.isLinux)
+        throw new Exception('Platform unsupported.');
       String url = googleStorageUrl(category, 'linux-x64') + name;
       await _downloadFile(url, cachedFile);
       if (_needsToBeExecutable(artifact)) {


### PR DESCRIPTION
There's not much point in downloading and trying to execute a linux-only binary on a mac host.
This produces a dart stacktrace, which isn't great but is a bit clearer and much faster than trying
to download+run a 50mb linux executable.