### PR TITLE
check all the dart code in the project, not just selected libraries

### DIFF
--- a/lib/src/artifacts.dart
+++ b/lib/src/artifacts.dart
@@ -45,7 +45,7 @@ class _ArtifactStore {
   }
 
   Future<String> getPath(Artifact artifact, String packageRoot) async {
-    String engineRevision = await _getEngineRevision(packageRoot); 
+    String engineRevision = await _getEngineRevision(packageRoot);
     Directory cacheDir = await _cacheDir(engineRevision, packageRoot);
 
     if (artifact == Artifact.FlutterCompiler) {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -8,10 +8,8 @@
 set -e
 
 # Verify that the libraries are error free.
-dartanalyzer --fatal-warnings \
-  bin/build_sky_apk.dart \
-  bin/sky_server.dart \
-  bin/sky_tools.dart
+pub global activate tuneup
+pub global run tuneup check
 
 # And run our tests.
 pub run test


### PR DESCRIPTION
Use the `tuneup` utility to check all the dart code in the project (`bin/`, `lib/`, `test/`, `tool/`, ...) instead of just selected libraries. This can help catch more analysis issues on the build bots.