### PR TITLE
Add cache command to sky_tools with subcommands for populating/clearing

### DIFF
--- a/bin/sky_tools.dart
+++ b/bin/sky_tools.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:sky_tools/src/build.dart';
+import 'package:sky_tools/src/cache.dart';
 import 'package:sky_tools/src/common.dart';
 import 'package:sky_tools/src/init.dart';
 import 'package:sky_tools/src/install.dart';
@@ -92,6 +93,7 @@ void main(List<String> args) {
 
   for (CommandHandler handler in [
     new BuildCommandHandler(),
+    new CacheCommandHandler(),
     new InitCommandHandler(),
     new InstallCommandHandler(),
     new RunMojoCommandHandler(),

--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -1,0 +1,68 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+library sky_tools.cache;
+
+import 'dart:async';
+
+import 'package:args/args.dart';
+import 'package:logging/logging.dart';
+
+import 'artifacts.dart';
+import 'common.dart';
+
+final Logger _logging = new Logger('sky_tools.cache');
+
+class CacheCommandHandler extends CommandHandler {
+  CacheCommandHandler() : super('cache', 'Manages sky_tools\' cache of binary artifacts.');
+
+  ArgParser get parser {
+    ArgParser parser = new ArgParser();
+    parser.addFlag('help', abbr: 'h', negatable: false);
+    parser.addOption('package-root', defaultsTo: 'packages');
+    ArgParser clearParser = parser.addCommand('clear');
+    clearParser.addFlag('help', abbr: 'h', negatable: false);
+    ArgParser populateParser = parser.addCommand('populate');
+    populateParser.addFlag('help', abbr: 'h', negatable: false);
+    return parser;
+  }
+
+  Future<int> _clear(String packageRoot, ArgResults results) async {
+    if (results['help']) {
+      print('Clears all artifacts from the cache.');
+      print(parser.usage);
+      return 0;
+    }
+    ArtifactStore artifacts = new ArtifactStore(packageRoot);
+    await artifacts.clear();
+    return 0;
+  }
+
+  Future<int> _populate(String packageRoot, ArgResults results) async {
+    if (results['help']) {
+      print('Populates the cache with all known artifacts.');
+      print(parser.usage);
+      return 0;
+    }
+    ArtifactStore artifacts = new ArtifactStore(packageRoot);
+    await artifacts.populate();
+    return 0;
+  }
+
+  @override
+  Future<int> processArgResults(ArgResults results) async {
+    if (results['help'] || results.command == null) {
+      print(parser.usage);
+      return 0;
+    }
+    if (results.command.name == 'clear') {
+      return _clear(results['package-root'], results.command);
+    } else if (results.command.name == 'populate') {
+      return _populate(results['package-root'], results.command);
+    } else {
+      _logging.severe('Unknown cache command \"${results.command.name}\"');
+      return 2;
+    }
+  }
+}


### PR DESCRIPTION
This adds the following commands to sky_tools:
  sky_tools cache clear: Nukes all local artifacts in the cache
  sky_tools cache populate: Populates the cache with all known artifacts

This is useful both to fix busted caches and to make sure that the cache is
fully populated so that subsequent operations can proceed without needing
network access.