### PR TITLE
Update mojo_run to no longer embed a window manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.0.15
+- fix mojo_run command to support sky_engine >= 0.0.27
+
 ## 0.0.8+3
 - added a dependency to the `sky_tools` package in the generated project template
 

--- a/lib/src/run_mojo.dart
+++ b/lib/src/run_mojo.dart
@@ -44,7 +44,9 @@ class RunMojoCommandHandler extends CommandHandler {
     String appName = path.basename(appPath);
     String appDir = path.dirname(appPath);
     List<String> args = [
-      '--android', '--release', '--embed', 'http://app/$appName',
+      '--android',
+      '--release',
+      'http://app/$appName',
       '--map-origin=http://app/=$appDir',
       '--map-origin=http://sky_viewer/=$skyViewerUrl',
       '--url-mappings=mojo:sky_viewer=http://sky_viewer/sky_viewer.mojo',
@@ -63,8 +65,8 @@ class RunMojoCommandHandler extends CommandHandler {
     String viewerPath = await _makePathAbsolute(await artifacts.getPath(Artifact.SkyViewerMojo));
     String mojoShellPath = await _makePathAbsolute(path.join(results['mojo-path'], 'out', 'Release', 'mojo_shell'));
     List<String> args = [
-      'mojo:window_manager file://${appPath}',
-      '--url-mappings=mojo:window_manager=mojo:kiosk_wm,mojo:sky_viewer=file://${viewerPath}'
+      'file://${appPath}',
+      '--url-mappings=mojo:sky_viewer=file://${viewerPath}'
     ];
     args.addAll(results.rest);
     return runCommandAndStreamOutput(mojoShellPath, args);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sky_tools
-version: 0.0.14
+version: 0.0.15
 description: Tools for building Sky applications
 homepage: https://github.com/domokit/sky_tools
 author: Chromium Authors <sky-dev@googlegroups.com>


### PR DESCRIPTION
sky_viewer.mojo no longer needs a window manager embedding as of
sky_engine 0.0.27, so this updates the sky_tools run_mojo command so it works
again. This really should be expressed in the pubspec dependencies to avoid
broken combinations but that needs to happen on the sky side.