### PR TITLE
more verbose test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ dart:
   - dev
   - stable
 script: ./tool/travis.sh
-cache:
-  directories:
-  - $HOME/.pub-cache

--- a/test/init_test.dart
+++ b/test/init_test.dart
@@ -36,6 +36,10 @@ defineTests() {
       ProcessResult exec = Process.runSync(
           'dartanalyzer', ['--fatal-warnings', path],
           workingDirectory: temp.path);
+      if (exec.exitCode != 0) {
+        print(exec.stdout);
+        print(exec.stderr);
+      }
       expect(exec.exitCode, 0);
     });
   });


### PR DESCRIPTION
Fix https://github.com/flutter/tools/pull/68, address the travis failures in https://github.com/flutter/tools/pull/67.

- make the `init` test more verbose when analysis fails
- remove the caching of the `.pub-cache` dir, since it looks like trying to maintain that cache was for some reason failing the travis builds

@iansf @chinmaygarde 