### PR TITLE
Forward additionalArgs in run_mojo.dart

### DIFF
--- a/lib/src/run_mojo.dart
+++ b/lib/src/run_mojo.dart
@@ -95,6 +95,7 @@ class RunMojoCommand extends Command {
     _MojoConfig mojoConfig = argResults['mojo-debug'] ? _MojoConfig.Debug : _MojoConfig.Release;
     String appPath = await _makePathAbsolute(argResults['app']);
 
+    args.addAll(argResults.rest);
     if (argResults['android']) {
       return _runAndroid(mojoPath, mojoConfig, appPath, args);
     } else {


### PR DESCRIPTION
In 0.0.15, additional cmdline arguments were not dropped, but now in 0.0.16, the arguments are no longer forwarded.
This patchset would restore this forwarding functionality.

For example, the following command is intended to pass `enable-multiprocess` to the mojo_shell.
`enable-multiprocess` in 0.0.16 does not get passed along, but this patchset would allow it to once again.

```
pub run sky_tools -v --very-verbose run_mojo \
	--mojo-path $MOJO_DIR/src \
	--app app.flx --android \
	-- \
	--enable-multiprocess
```