### PR TITLE
remove an unused import

### DIFF
--- a/lib/src/commands/init.dart
+++ b/lib/src/commands/init.dart
@@ -140,7 +140,6 @@ dev_dependencies:
 
 const _libMain = r'''
 import 'package:sky/material.dart';
-import 'package:sky/widgets.dart';
 
 void main() {
   runApp(


### PR DESCRIPTION
Follow up to https://github.com/flutter/tools/pull/84, remove an unused import statement.

@abarth 