### PR TITLE
Refactor the build command so that it can be used internally

### DIFF
--- a/lib/src/commands/flutter_command.dart
+++ b/lib/src/commands/flutter_command.dart
@@ -8,6 +8,7 @@ import 'package:args/command_runner.dart';
 
 import '../application_package.dart';
 import '../device.dart';
+import '../toolchain.dart';
 import 'flutter_command_runner.dart';
 
 abstract class FlutterCommand extends Command {
@@ -16,6 +17,11 @@ abstract class FlutterCommand extends Command {
   Future downloadApplicationPackages() async {
     if (applicationPackages == null)
       applicationPackages = await ApplicationPackageStore.forConfigs(runner.buildConfigurations);
+  }
+
+  Future downloadToolchain() async {
+    if (toolchain == null)
+      toolchain = await Toolchain.forConfigs(runner.buildConfigurations);
   }
 
   void connectToDevices() {
@@ -30,9 +36,11 @@ abstract class FlutterCommand extends Command {
 
   void inheritFromParent(FlutterCommand other) {
     applicationPackages = other.applicationPackages;
+    toolchain = other.toolchain;
     devices = other.devices;
   }
 
   ApplicationPackageStore applicationPackages;
+  Toolchain toolchain;
   DeviceStore devices;
 }

--- a/lib/src/toolchain.dart
+++ b/lib/src/toolchain.dart
@@ -1,0 +1,45 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:path/path.dart' as path;
+
+import 'artifacts.dart';
+import 'build_configuration.dart';
+import 'process.dart';
+
+class Compiler {
+  Compiler(this._compilerPath);
+
+  String _compilerPath;
+
+  Future<int> compile({
+    String mainPath,
+    String snapshotPath
+  }) {
+    return runCommandAndStreamOutput([
+      _compilerPath,
+      mainPath,
+      '--package-root=${ArtifactStore.packageRoot}',
+      '--snapshot=$snapshotPath'
+    ]);
+  }
+}
+
+class Toolchain {
+  Toolchain({ this.compiler });
+
+  final Compiler compiler;
+
+  static Future<Toolchain> forConfigs(List<BuildConfiguration> configs) async {
+    // TODO(abarth): Add a notion of "host platform" to the build configs.
+    BuildConfiguration config = configs.first;
+    String compilerPath = config.type == BuildType.prebuilt ?
+        await ArtifactStore.getPath(Artifact.flutterCompiler) :
+        path.join(config.buildDir, 'clang_x64', 'sky_snapshot');
+
+    return new Toolchain(compiler: new Compiler(compilerPath));
+  }
+}

--- a/test/src/mocks.dart
+++ b/test/src/mocks.dart
@@ -7,12 +7,22 @@ import 'package:sky_tools/src/application_package.dart';
 import 'package:sky_tools/src/build_configuration.dart';
 import 'package:sky_tools/src/commands/flutter_command.dart';
 import 'package:sky_tools/src/device.dart';
+import 'package:sky_tools/src/toolchain.dart';
 
 class MockApplicationPackageStore extends ApplicationPackageStore {
   MockApplicationPackageStore() : super(
     android: new AndroidApk(localPath: '/mock/path/to/android/SkyShell.apk'),
     iOS: new IOSApp(localPath: '/mock/path/to/iOS/SkyShell.app'),
     iOSSimulator: new IOSApp(localPath: '/mock/path/to/iOSSimulator/SkyShell.app'));
+}
+
+class MockCompiler extends Mock implements Compiler {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class MockToolchain extends Toolchain {
+  MockToolchain() : super(compiler: new MockCompiler());
 }
 
 class MockAndroidDevice extends Mock implements AndroidDevice {
@@ -46,5 +56,6 @@ class MockDeviceStore extends DeviceStore {
 void applyMocksToCommand(FlutterCommand command) {
   command
     ..applicationPackages = new MockApplicationPackageStore()
+    ..toolchain = new MockToolchain()
     ..devices = new MockDeviceStore();
 }


### PR DESCRIPTION
Instead of calling through `pub` to invoke build, this patch refactors the
build command so that it can be called directly.