### PR TITLE
Add a --local-build flag to detect engine src paths

### DIFF
--- a/lib/src/commands/flutter_command_runner.dart
+++ b/lib/src/commands/flutter_command_runner.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
 
 import '../artifacts.dart';
 import '../build_configuration.dart';
@@ -30,49 +31,55 @@ class FlutterCommandRunner extends CommandRunner {
     argParser.addFlag('debug',
         negatable: false,
         help:
-            'Set this if you are building Sky locally and want to use the debug build products. '
-            'When set, attempts to automaticaly determine sky-src-path if sky-src-path is '
+            'Set this if you are building Flutter locally and want to use the debug build products. '
+            'When set, attempts to automaticaly determine engine-src-path if engine-src-path is '
             'not set. Not normally required.');
     argParser.addFlag('release',
         negatable: false,
         help:
-            'Set this if you are building Sky locally and want to use the release build products. '
-            'When set, attempts to automaticaly determine sky-src-path if sky-src-path is '
+            'Set this if you are building Flutter locally and want to use the release build products. '
+            'When set, attempts to automaticaly determine engine-src-path if engine-src-path is '
             'not set. Note that release is not compatible with the listen command '
             'on iOS devices and simulators. Not normally required.');
-    argParser.addOption('sky-src-path',
+    argParser.addFlag('local-build',
+        negatable: false,
         help:
-            'Path to your Sky src directory, if you are building Sky locally. '
+            'Automatically detect your engine src directory from an overridden Flutter package.'
+            'Useful if you are building Flutter locally and are using a dependency_override for'
+            'the Flutter package that points to your engine src directory.');
+    argParser.addOption('engine-src-path',
+        help:
+            'Path to your engine src directory, if you are building Flutter locally. '
             'Ignored if neither debug nor release is set. Not normally required.');
     argParser.addOption('android-debug-build-path',
         help:
-            'Path to your Android Debug out directory, if you are building Sky locally. '
-            'This path is relative to sky-src-path. Not normally required.',
+            'Path to your Android Debug out directory, if you are building Flutter locally. '
+            'This path is relative to engine-src-path. Not normally required.',
         defaultsTo: 'out/android_Debug/');
     argParser.addOption('android-release-build-path',
         help:
-            'Path to your Android Release out directory, if you are building Sky locally. '
-            'This path is relative to sky-src-path. Not normally required.',
+            'Path to your Android Release out directory, if you are building Flutter locally. '
+            'This path is relative to engine-src-path. Not normally required.',
         defaultsTo: 'out/android_Release/');
     argParser.addOption('ios-debug-build-path',
         help:
-            'Path to your iOS Debug out directory, if you are building Sky locally. '
-            'This path is relative to sky-src-path. Not normally required.',
+            'Path to your iOS Debug out directory, if you are building Flutter locally. '
+            'This path is relative to engine-src-path. Not normally required.',
         defaultsTo: 'out/ios_Debug/');
     argParser.addOption('ios-release-build-path',
         help:
-            'Path to your iOS Release out directory, if you are building Sky locally. '
-            'This path is relative to sky-src-path. Not normally required.',
+            'Path to your iOS Release out directory, if you are building Flutter locally. '
+            'This path is relative to engine-src-path. Not normally required.',
         defaultsTo: 'out/ios_Release/');
     argParser.addOption('ios-sim-debug-build-path',
         help:
             'Path to your iOS Simulator Debug out directory, if you are building Sky locally. '
-            'This path is relative to sky-src-path. Not normally required.',
+            'This path is relative to engine-src-path. Not normally required.',
         defaultsTo: 'out/ios_sim_Debug/');
     argParser.addOption('ios-sim-release-build-path',
         help:
             'Path to your iOS Simulator Release out directory, if you are building Sky locally. '
-            'This path is relative to sky-src-path. Not normally required.',
+            'This path is relative to engine-src-path. Not normally required.',
         defaultsTo: 'out/ios_sim_Release/');
     argParser.addOption('package-root',
         help: 'Path to your packages directory.', defaultsTo: 'packages');
@@ -106,8 +113,18 @@ class FlutterCommandRunner extends CommandRunner {
   }
 
   List<BuildConfiguration> _createBuildConfigurations(ArgResults globalResults) {
-    // TODO(iansf): Figure out how to get the default src path
-    String enginePath = globalResults['sky-src-path'];
+    String enginePath = globalResults['engine-src-path'];
+    bool isDebug = globalResults['debug'];
+    bool isRelease = globalResults['release'];
+
+    if (enginePath == null && globalResults['local-build']) {
+      Directory flutterDir = new Directory(path.join(globalResults['package-root'], 'flutter'));
+      String realFlutterPath = flutterDir.resolveSymbolicLinksSync();
+
+      enginePath = path.dirname(path.dirname(path.dirname(path.dirname(realFlutterPath))));
+      if (enginePath == '/' || enginePath.isEmpty)
+        enginePath = null;
+    }
 
     List<BuildConfiguration> configs = <BuildConfiguration>[];
 
@@ -117,7 +134,10 @@ class FlutterCommandRunner extends CommandRunner {
       if (!FileSystemEntity.isDirectorySync(enginePath))
         _logging.warning('$enginePath is not a valid directory');
 
-      if (globalResults['debug']) {
+      if (!isDebug && !isRelease)
+        isDebug = true;
+
+      if (isDebug) {
         configs.add(new BuildConfiguration.local(
           type: BuildType.debug,
           platform: BuildPlatform.android,
@@ -142,7 +162,7 @@ class FlutterCommandRunner extends CommandRunner {
         }
       }
 
-      if (globalResults['release']) {
+      if (isRelease) {
         configs.add(new BuildConfiguration.local(
           type: BuildType.release,
           platform: BuildPlatform.android,


### PR DESCRIPTION
A common use case for members of the Flutter team is to have a dependency
override for the flutter package that points back into the engine src tree.
We can use that override to automatically detect the engine src path, which
makes the command line shorter.