### PR TITLE
run_mojo can't find ArtifactStore.packageRoot

### DIFF
--- a/lib/src/commands/flutter_command_runner.dart
+++ b/lib/src/commands/flutter_command_runner.dart
@@ -102,11 +102,12 @@ class FlutterCommandRunner extends CommandRunner {
       Logger.root.level = Level.FINE;
 
     _globalResults = globalResults;
+    ArtifactStore.packageRoot = globalResults['package-root'];
+
     return super.runCommand(globalResults);
   }
 
   List<BuildConfiguration> _createBuildConfigurations(ArgResults globalResults) {
-    ArtifactStore.packageRoot = globalResults['package-root'];
     if (!FileSystemEntity.isDirectorySync(ArtifactStore.packageRoot)) {
       String message = '${ArtifactStore.packageRoot} is not a valid directory.';
       if (ArtifactStore.packageRoot == 'packages') {


### PR DESCRIPTION
The `run_mojo` command doesn't integrate with `FlutterCommand` and doesn't
understand how to download its toolchain components ahead of time. Eventually
we should teach `run_mojo` how to integrate with the `Toolchain` class, but
until then, we can fix the regression by eagerly setting
`ArtifactStore.packageRoot` again.

Fixes https://github.com/domokit/mojo/issues/475