### PR TITLE
return exit codes on failures

### DIFF
--- a/bin/sky_server.dart
+++ b/bin/sky_server.dart
@@ -5,10 +5,10 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:shelf_static/shelf_static.dart';
-import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_route/shelf_route.dart' as shelf_route;
+import 'package:shelf_static/shelf_static.dart';
 
 void printUsage(parser) {
   print('Usage: sky_server [-v] PORT');

--- a/bin/sky_test.dart
+++ b/bin/sky_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/src/executable.dart' as executable;
 import 'package:sky_tools/src/test/loader.dart' as loader;
+import 'package:test/src/executable.dart' as executable;
 
 main(List<String> args) {
   loader.installHook();

--- a/lib/src/commands/flutter_command_runner.dart
+++ b/lib/src/commands/flutter_command_runner.dart
@@ -94,7 +94,7 @@ class FlutterCommandRunner extends CommandRunner {
 
   ArgResults _globalResults;
 
-  Future<int> runCommand(ArgResults globalResults) async {
+  Future<int> runCommand(ArgResults globalResults) {
     if (globalResults['verbose'])
       Logger.root.level = Level.INFO;
 

--- a/lib/src/commands/list.dart
+++ b/lib/src/commands/list.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 
-import 'flutter_command.dart';
 import '../device.dart';
+import 'flutter_command.dart';
 
 final Logger _logging = new Logger('sky_tools.list');
 

--- a/lib/src/commands/logs.dart
+++ b/lib/src/commands/logs.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 
-import 'flutter_command.dart';
 import '../device.dart';
+import 'flutter_command.dart';
 
 final Logger _logging = new Logger('sky_tools.logs');
 

--- a/lib/src/commands/run_mojo.dart
+++ b/lib/src/commands/run_mojo.dart
@@ -31,17 +31,17 @@ class RunMojoCommand extends Command {
   }
 
   // TODO(abarth): Why not use path.absolute?
-  Future<String> _makePathAbsolute(String relativePath) async {
+  String _makePathAbsolute(String relativePath) {
     File file = new File(relativePath);
-    if (!await file.exists()) {
+    if (!file.existsSync()) {
       throw new Exception("Path \"${relativePath}\" does not exist");
     }
     return file.absolute.path;
   }
 
-  Future<int> _runAndroid(String mojoPath, _MojoConfig mojoConfig, String appPath, List<String> additionalArgs) async {
+  Future<int> _runAndroid(String mojoPath, _MojoConfig mojoConfig, String appPath, List<String> additionalArgs) {
     String skyViewerUrl = ArtifactStore.googleStorageUrl('viewer', 'android-arm');
-    String command = await _makePathAbsolute(path.join(mojoPath, 'mojo', 'devtools', 'common', 'mojo_run'));
+    String command = _makePathAbsolute(path.join(mojoPath, 'mojo', 'devtools', 'common', 'mojo_run'));
     String appName = path.basename(appPath);
     String appDir = path.dirname(appPath);
     String buildFlag = mojoConfig == _MojoConfig.Debug ? '--debug' : '--release';
@@ -65,9 +65,9 @@ class RunMojoCommand extends Command {
   }
 
   Future<int> _runLinux(String mojoPath, _MojoConfig mojoConfig, String appPath, List<String> additionalArgs) async {
-    String viewerPath = await _makePathAbsolute(await ArtifactStore.getPath(Artifact.skyViewerMojo));
+    String viewerPath = _makePathAbsolute(await ArtifactStore.getPath(Artifact.skyViewerMojo));
     String mojoBuildType = mojoConfig == _MojoConfig.Debug ? 'Debug' : 'Release';
-    String mojoShellPath = await _makePathAbsolute(path.join(mojoPath, 'out', mojoBuildType, 'mojo_shell'));
+    String mojoShellPath = _makePathAbsolute(path.join(mojoPath, 'out', mojoBuildType, 'mojo_shell'));
     List<String> cmd = [
       mojoShellPath,
       'file://${appPath}',
@@ -93,7 +93,7 @@ class RunMojoCommand extends Command {
     }
     String mojoPath = argResults['mojo-path'];
     _MojoConfig mojoConfig = argResults['mojo-debug'] ? _MojoConfig.Debug : _MojoConfig.Release;
-    String appPath = await _makePathAbsolute(argResults['app']);
+    String appPath = _makePathAbsolute(argResults['app']);
 
     args.addAll(argResults.rest);
     if (argResults['android']) {

--- a/lib/src/commands/start.dart
+++ b/lib/src/commands/start.dart
@@ -67,6 +67,14 @@ class StartCommand extends FlutterCommand {
       }
     }
 
+    if (!startedSomething) {
+      if (!devices.all.any((device) => device.isConnected())) {
+        _logging.severe('Unable to run application - no connected devices.');
+      } else {
+        _logging.severe('Unable to run application.');
+      }
+    }
+
     return startedSomething ? 0 : 2;
   }
 }

--- a/lib/src/commands/trace.dart
+++ b/lib/src/commands/trace.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 
-import 'flutter_command.dart';
 import '../application_package.dart';
 import '../device.dart';
+import 'flutter_command.dart';
 
 final Logger _logging = new Logger('sky_tools.trace');
 

--- a/lib/src/device.dart
+++ b/lib/src/device.dart
@@ -277,7 +277,7 @@ class IOSDevice extends Device {
       return 2;
     }
     return runCommandAndStreamOutput([loggerPath],
-        prefix: 'IOS DEV: ', filter: new RegExp(r'.*SkyShell.*'));
+        prefix: 'iOS dev: ', filter: new RegExp(r'.*SkyShell.*'));
   }
 }
 
@@ -499,7 +499,7 @@ class IOSSimulator extends Device {
       runSync(['rm', logFilePath]);
     }
     return runCommandAndStreamOutput(['tail', '-f', logFilePath],
-        prefix: 'IOS SIM: ', filter: new RegExp(r'.*SkyShell.*'));
+        prefix: 'iOS sim: ', filter: new RegExp(r'.*SkyShell.*'));
   }
 }
 
@@ -575,7 +575,7 @@ class AndroidDevice extends Device {
     _hasValidAndroid = _checkForLollipopOrLater();
 
     if (!_hasAdb || !_hasValidAndroid) {
-      _logging.severe('Unable to run on Android.');
+      _logging.warning('Unable to run on Android.');
     }
   }
 
@@ -855,7 +855,7 @@ class AndroidDevice extends Device {
       '-s',
       'sky',
       'chromium',
-    ], prefix: 'ANDROID: ');
+    ], prefix: 'android: ');
   }
 
   void startTracing(AndroidApk apk) {

--- a/test/stop_test.dart
+++ b/test/stop_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library stop_test;
-
 import 'package:args/command_runner.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sky_tools/src/commands/stop.dart';

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library trace_test;
-
 import 'package:args/command_runner.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sky_tools/src/commands/trace.dart';


### PR DESCRIPTION
fix #103

- print severe logging messages and exceptions to stderr (instead of stdout)
- pass the exit codes from commands through to the process exit
- add an error message when we're not able to launch an app (from the `start` command)
- use `fooSync()` methods instead of `await` and async methods where possible

@abarth 