### PR TITLE
set a min. dep of sdk 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: dart
 sudo: false
 dart:
   - dev
-  - stable
+# TODO: Re-enable once 1.13 hits stable.
+#  - stable
 script: ./tool/travis.sh

--- a/lib/src/commands/init.dart
+++ b/lib/src/commands/init.dart
@@ -24,7 +24,7 @@ class InitCommand extends Command {
   Future<int> run() async {
     if (!argResults.wasParsed('out')) {
       print('No option specified for the output directory.');
-      print(argParser.getUsage());
+      print(argParser.usage);
       return 2;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://flutter.io
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
-  sdk: ">=1.8.0 <2.0.0"
+  sdk: '>=1.13.0-dev.1 <2.0.0'
 
 dependencies:
   archive: ^1.0.20


### PR DESCRIPTION
Fix the travis build; only test against the `dev` SDK for now. We can test against dev and stable again once 1.13 goes stable.

```
Checking project sky_tools...
1 issue found; analyzed 39 source files in 14.1s.
[warning] Undefined name 'BASE64' at lib/src/signing.dart, line 49.
```

@mpcomplete 