### PR TITLE
Don't rely on external shasum program to calculate sum of the APK.

### DIFF
--- a/lib/src/device.dart
+++ b/lib/src/device.dart
@@ -10,6 +10,7 @@ import 'dart:math';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:crypto/crypto.dart';
 
 import 'application_package.dart';
 import 'build_configuration.dart';
@@ -695,9 +696,10 @@ class AndroidDevice extends Device {
   }
 
   String _getSourceSha1(ApplicationPackage app) {
-    String sha1 =
-        runCheckedSync(['shasum', '-a', '1', '-p', app.localPath]).split(' ')[0];
-    return sha1;
+    var sha1 = new SHA1();
+    var file = new File(app.localPath);
+    sha1.add(file.readAsBytesSync());
+    return CryptoUtils.bytesToHex(sha1.close());
   }
 
   @override
@@ -765,7 +767,7 @@ class AndroidDevice extends Device {
 
       // Actually start the server.
       await Process.start('pub', ['run', 'sky_tools:sky_server', _serverPort],
-          workingDirectory: serverRoot, mode: ProcessStartMode.DETACHED);
+          workingDirectory: serverRoot, mode: ProcessStartMode.DETACHED, runInShell: Platform.isWindows);
 
       // Set up reverse port-forwarding so that the Android app can reach the
       // server running on localhost.
@@ -824,6 +826,26 @@ class AndroidDevice extends Device {
       // equivalent command when doing verbose logging.
       _logging.info('kill $pid');
       Process.killPid(int.parse(pid));
+    } else if (Platform.isWindows) {
+      //Get list of network processes and split on newline
+      List<String> processes = runSync(['netstat.exe','-ano']).split("\r");
+
+      //List entries from netstat is formatted like so
+      // TCP    192.168.2.11:50945     192.30.252.90:443      LISTENING     1304
+      //This regexp is to find process where the the port exactly matches
+      RegExp pattern = new RegExp(':$_serverPort[ ]+');
+
+      //Split the columns by 1 or more spaces
+      RegExp columnPattern = new RegExp('[ ]+');
+      processes.forEach((String process){
+        if (process.contains(pattern)) {
+          //The last column is the Process ID
+          String processId = process.split(columnPattern).last;
+          //Force and Tree kill the process
+          _logging.info('kill $processId');
+          runSync(['TaskKill.exe', '/F', '/T', '/PID', processId]);
+        }
+      });
     } else {
       runSync(['fuser', '-k', '$_serverPort/tcp']);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   shelf: ^0.6.2
   test: ">=0.12.4+5 <0.12.5"
   yaml: ^2.1.3
+  crypto: ^0.9.1
 
 dev_dependencies:
   mockito: "^0.10.1"


### PR DESCRIPTION
Replaces PR #120

Windows has no direct way to kill a process based on port. Uses netstats and loops through the results to find the correct process to kill.

Also modify Process.run for the server to runInShell if on Windows.

Style nits.