### PR TITLE
Rev the Dart SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: sky_tools
-version: 0.0.27
+version: 0.0.28
 description: Tools for building Flutter applications
 homepage: http://flutter.io
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
-  sdk: '>=1.13.0-dev.1 <2.0.0'
+  sdk: '>=1.13.0-dev.7.4 <2.0.0'
 
 dependencies:
   archive: ^1.0.20
@@ -19,7 +19,7 @@ dependencies:
   shelf_route: ^0.13.4
   shelf_static: ^0.2.3
   shelf: ^0.6.2
-  test: ">=0.12.4+5 <0.12.5"
+  test: ^0.12.5
   yaml: ^2.1.3
 
 dev_dependencies:


### PR DESCRIPTION
We also have to require a newer test package, since the old one depends
on a version of the analyzer that uses dart:profiler, which is gone and
replaced by dart:developer.

See also https://github.com/flutter/engine/pull/1732