### PR TITLE
Fix win bot

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build: off
 test_script:
   - pub global activate tuneup
   - pub global run tuneup check
-  - pub run test -j1
+  - dart --checked test\all.dart

--- a/test/all.dart
+++ b/test/all.dart
@@ -1,0 +1,25 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'android_device_test.dart' as android_device_test;
+import 'init_test.dart' as init_test;
+import 'install_test.dart' as install_test;
+import 'listen_test.dart' as listen_test;
+import 'list_test.dart' as list_test;
+import 'logs_test.dart' as logs_test;
+import 'start_test.dart' as start_test;
+import 'stop_test.dart' as stop_test;
+import 'trace_test.dart' as trace_test;
+
+main() {
+  android_device_test.defineTests();
+  init_test.defineTests();
+  install_test.defineTests();
+  listen_test.defineTests();
+  list_test.defineTests();
+  logs_test.defineTests();
+  start_test.defineTests();
+  stop_test.defineTests();
+  trace_test.defineTests();
+}

--- a/test/init_test.dart
+++ b/test/init_test.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// This test can take a while due to network requests.
-@Timeout(const Duration(minutes: 2))
-library init_test;
-
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
@@ -46,6 +42,8 @@ defineTests() {
         print(exec.stderr);
       }
       expect(exec.exitCode, 0);
-    });
+    },
+    // This test can take a while due to network requests.
+    timeout: new Timeout(new Duration(minutes: 2)));
   });
 }


### PR DESCRIPTION
Fix the appveyor build:
- create an all.dart test script to work around an issue with pub run test
- change how we specify test timeout (a bare test file doesn't know about annotations)
