### PR TITLE
pick an older version of test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   shelf_route: ^0.13.4
   shelf_static: ^0.2.3
   shelf: ^0.6.2
-  test: ^0.12.5
+  test: 0.12.4+9
   yaml: ^2.1.3
 
 dev_dependencies:


### PR DESCRIPTION
Pick an older version of `test` - this version of test works with 1.13.0 SDKs, but also supports the plugin mechanism we're using.

@Hixie, was there a reason you revd to `0.12.5`, or will this version work as well?