### PR TITLE
verify that we're running from the root of a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # CHANGELOG
 
+## unreleased
+- Changed some `sky_tools` commands to enforce that they're run from a project
+  root
+
 ## 0.0.28
-- Depend on a more recent version of test, since the old version
-  indirectly referenced the now-obsolete VM package dart:profiler.
+- Depend on a more recent version of test, since the old version indirectly
+  referenced the now-obsolete VM package dart:profiler.
+
+## 0.0.27
+- fixed issues running `sky_tools start` on Windows
 
 ## 0.0.26
 - Add the --precompiled option to the build command that indicates a script

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -20,6 +20,7 @@ import 'src/commands/run_mojo.dart';
 import 'src/commands/start.dart';
 import 'src/commands/stop.dart';
 import 'src/commands/trace.dart';
+import 'src/process.dart';
 
 /// Main entry point for commands.
 ///
@@ -58,6 +59,16 @@ Future main(List<String> args) async {
       exit(result);
   } on UsageException catch (e) {
     stderr.writeln(e);
-    exit(4);
+    // Args error exit code.
+    exit(64);
+  } catch (e, stack) {
+    if (e is ProcessExit) {
+      // We've caught an exit code.
+      exit(e.exitCode);
+    }
+
+    stderr.writeln(e);
+    Logger.root.log(Level.SEVERE, '\nException:', null, stack);
+    exit(1);
   }
 }

--- a/lib/src/commands/build.dart
+++ b/lib/src/commands/build.dart
@@ -127,7 +127,7 @@ class BuildCommand extends FlutterCommand {
   }
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     String compilerPath = argResults['compiler'];
 
     if (compilerPath == null)

--- a/lib/src/commands/flutter_command.dart
+++ b/lib/src/commands/flutter_command.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:args/command_runner.dart';
 
@@ -13,6 +14,9 @@ import 'flutter_command_runner.dart';
 
 abstract class FlutterCommand extends Command {
   FlutterCommandRunner get runner => super.runner;
+
+  /// Whether this command needs to be run from the root of a project.
+  bool get requiresProjectRoot => true;
 
   Future downloadApplicationPackages() async {
     if (applicationPackages == null)
@@ -39,6 +43,20 @@ abstract class FlutterCommand extends Command {
     toolchain = other.toolchain;
     devices = other.devices;
   }
+
+  Future<int> run() async {
+    if (requiresProjectRoot) {
+      if (!FileSystemEntity.isFileSync('pubspec.yaml')) {
+        stderr.writeln('No pubspec.yaml file found. '
+            'This command should be run from the root of a project.');
+        return 1;
+      }
+    }
+
+    return runInProject();
+  }
+
+  Future<int> runInProject();
 
   ApplicationPackageStore applicationPackages;
   Toolchain toolchain;

--- a/lib/src/commands/flutter_command_runner.dart
+++ b/lib/src/commands/flutter_command_runner.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as path;
 
 import '../artifacts.dart';
 import '../build_configuration.dart';
+import '../process.dart';
 
 final Logger _logging = new Logger('sky_tools.flutter_command_runner');
 
@@ -116,8 +117,8 @@ class FlutterCommandRunner extends CommandRunner {
         else
           message += '\nDid you run this command from the same directory as your pubspec.yaml file?';
       }
-      _logging.severe(message);
-      exit(2);
+      stderr.writeln(message);
+      throw new ProcessExit(2);
     }
 
     String enginePath = globalResults['engine-src-path'];
@@ -129,9 +130,11 @@ class FlutterCommandRunner extends CommandRunner {
       String realFlutterPath = flutterDir.resolveSymbolicLinksSync();
 
       enginePath = path.dirname(path.dirname(path.dirname(path.dirname(realFlutterPath))));
-      if (enginePath == '/' || enginePath.isEmpty || !FileSystemEntity.isDirectorySync(path.join(enginePath, 'out'))) {
-        _logging.severe('Unable to detect local build in $enginePath.\nDo you have a dependency override for the flutter package?');
-        exit(2);
+      bool dirExists = FileSystemEntity.isDirectorySync(path.join(enginePath, 'out'));
+      if (enginePath == '/' || enginePath.isEmpty || !dirExists) {
+        stderr.writeln('Unable to detect local build in $enginePath.\n'
+            'Do you have a dependency override for the flutter package?');
+        throw new ProcessExit(2);
       }
     }
 

--- a/lib/src/commands/init.dart
+++ b/lib/src/commands/init.dart
@@ -160,8 +160,7 @@ class FlutterDemo extends StatelessComponent {
        ),
       floatingActionButton: new FloatingActionButton(
         child: new Icon(
-          type: 'content/add',
-          size: 24
+          type: 'content/add'
         )
       )
     );

--- a/lib/src/commands/install.dart
+++ b/lib/src/commands/install.dart
@@ -18,7 +18,7 @@ class InstallCommand extends FlutterCommand {
   }
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
     return install(boot: argResults['boot']) ? 0 : 2;
   }

--- a/lib/src/commands/list.dart
+++ b/lib/src/commands/list.dart
@@ -23,7 +23,7 @@ class ListCommand extends FlutterCommand {
   }
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     connectToDevices();
 
     bool details = argResults['details'];

--- a/lib/src/commands/listen.dart
+++ b/lib/src/commands/listen.dart
@@ -38,7 +38,7 @@ class ListenCommand extends FlutterCommand {
   static const String _remoteFlutterBundle = 'Documents/app.flx';
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
     await downloadToolchain();
 

--- a/lib/src/commands/logs.dart
+++ b/lib/src/commands/logs.dart
@@ -22,7 +22,7 @@ class LogsCommand extends FlutterCommand {
   }
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     connectToDevices();
 
     bool clear = argResults['clear'];

--- a/lib/src/commands/start.dart
+++ b/lib/src/commands/start.dart
@@ -36,7 +36,7 @@ class StartCommand extends FlutterCommand {
   }
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
 
     bool poke = argResults['poke'];

--- a/lib/src/commands/stop.dart
+++ b/lib/src/commands/stop.dart
@@ -17,7 +17,7 @@ class StopCommand extends FlutterCommand {
   final String description = 'Stop your Flutter app on all attached devices.';
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
     return await stop() ? 0 : 2;
   }

--- a/lib/src/commands/trace.dart
+++ b/lib/src/commands/trace.dart
@@ -28,7 +28,7 @@ class TraceCommand extends FlutterCommand {
   }
 
   @override
-  Future<int> run() async {
+  Future<int> runInProject() async {
     await downloadApplicationPackagesAndConnectToDevices();
 
     if (!devices.android.isConnected()) {

--- a/lib/src/process.dart
+++ b/lib/src/process.dart
@@ -89,3 +89,10 @@ String _runWithLoggingSync(List<String> cmd, {bool checked: false}) {
   _logging.fine(results.stdout.trim());
   return results.stdout;
 }
+
+class ProcessExit implements Exception {
+  final int exitCode;
+  ProcessExit(this.exitCode);
+  String get message => 'ProcessExit: ${exitCode}';
+  String toString() => message;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   shelf_route: ^0.13.4
   shelf_static: ^0.2.3
   shelf: ^0.6.2
-  test: ^0.12.5
+  test: 0.12.4+9
   yaml: ^2.1.3
 
 dev_dependencies:


### PR DESCRIPTION
- change some early calls to `exit()` to throw instead (fix #107)
- make many commands that require being run in a project root fast fail if they can't find a pubspec (fix #96)
- change some places where we're logging issues to instead write to stderr
- fix an analysis issue in the sample app we create

