### PR TITLE
increase test timeout

### DIFF
--- a/test/init_test.dart
+++ b/test/init_test.dart
@@ -44,6 +44,6 @@ defineTests() {
       expect(exec.exitCode, 0);
     },
     // This test can take a while due to network requests.
-    timeout: new Timeout(new Duration(minutes: 2)));
+    timeout: new Timeout(new Duration(minutes: 3)));
   });
 }


### PR DESCRIPTION
Increase a test timeout. The test for `init` is very slow on the windows bot. Perhaps due to unpacking large packages (that material design icons one?). The test runs pub get for a sample flutter app.

Test failure: https://ci.appveyor.com/project/devoncarew/tools/build/1.0.56