### PR TITLE
Handle crashing engine.

### DIFF
--- a/lib/src/test/json_socket.dart
+++ b/lib/src/test/json_socket.dart
@@ -7,11 +7,12 @@ import 'dart:convert';
 import 'dart:io';
 
 class JSONSocket {
-  JSONSocket(WebSocket socket)
+  JSONSocket(WebSocket socket, this.unusualTermination)
     : _socket = socket, stream = socket.map(JSON.decode).asBroadcastStream();
 
   final WebSocket _socket;
   final Stream stream;
+  final Future unusualTermination;
 
   void send(dynamic data) {
     _socket.add(JSON.encode(data));

--- a/lib/src/test/loader.dart
+++ b/lib/src/test/loader.dart
@@ -90,6 +90,7 @@ void main() {
 ''');
 
   Completer<Iterable<RemoteTest>> completer = new Completer<Iterable<RemoteTest>>();
+  Completer deathCompleter = new Completer();
 
   Process process = await _startProcess(
     listenerFile.path,
@@ -138,6 +139,7 @@ void main() {
         if (kExpectAllTestsToCloseCleanly && output != '')
           print('Unexpected failure after test claimed to pass:\n$output');
       }
+      deathCompleter.complete();
     } catch (e) {
       // Throwing inside this block causes all kinds of hard-to-debug issues
       // like stack overflows and hangs. So catch everything just in case.
@@ -145,7 +147,7 @@ void main() {
     }
   });
 
-  JSONSocket socket = new JSONSocket(await info.socket);
+  JSONSocket socket = new JSONSocket(await info.socket, deathCompleter.future);
 
   await cleanupTempDirectory();
 


### PR DESCRIPTION
When the engine dies unexpectedly during test execution, we have to
terminate any tests running in that engine. Previously, they would just
hang. For some reason that I was never able to satisfactorily explain,
the WebSocket doesn't die in a way I can detect in this case. So
instead, we hand in a future that we only complete when we detect the
server subprocess ends.