### PR TITLE
fix the 'dart:profiler' bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.0.33
+- Explicitly depend on a new version of 'analyzer' since old ones are
+  causing problems.
+
 ## 0.0.32
 - Make the test framework handle a crashing engine.
 

--- a/lib/src/test/json_socket.dart
+++ b/lib/src/test/json_socket.dart
@@ -12,7 +12,7 @@ class JSONSocket {
 
   final WebSocket _socket;
   final Stream stream;
-  final Future unusualTermination;
+  final Future<String> unusualTermination;
 
   void send(dynamic data) {
     _socket.add(JSON.encode(data));

--- a/lib/src/test/loader.dart
+++ b/lib/src/test/loader.dart
@@ -90,7 +90,7 @@ void main() {
 ''');
 
   Completer<Iterable<RemoteTest>> completer = new Completer<Iterable<RemoteTest>>();
-  Completer deathCompleter = new Completer();
+  Completer<String> deathCompleter = new Completer();
 
   Process process = await _startProcess(
     listenerFile.path,
@@ -139,7 +139,7 @@ void main() {
         if (kExpectAllTestsToCloseCleanly && output != '')
           print('Unexpected failure after test claimed to pass:\n$output');
       }
-      deathCompleter.complete();
+      deathCompleter.complete(output);
     } catch (e) {
       // Throwing inside this block causes all kinds of hard-to-debug issues
       // like stack overflows and hangs. So catch everything just in case.

--- a/lib/src/test/remote_test.dart
+++ b/lib/src/test/remote_test.dart
@@ -53,8 +53,9 @@ class RemoteTest extends Test {
         }
       });
 
-      _socket.unusualTermination.then((_) {
+      _socket.unusualTermination.then((String message) {
         if (subscription != null) {
+          controller.print('Unexpected subprocess termination: $message');
           controller.addError(new Exception('Unexpected subprocess termination.'), new Trace.current());
           controller.setState(new State(Status.complete, Result.error));
           subscription.cancel();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sky_tools
-version: 0.0.32
+version: 0.0.33
 description: Tools for building Flutter applications
 homepage: http://flutter.io
 author: Flutter Authors <flutter-dev@googlegroups.com>
@@ -8,6 +8,7 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dependencies:
+  analyzer: ">=0.26.1+17" # see note below
   archive: ^1.0.20
   args: ^0.13.0
   flx: ">=0.0.1 <0.1.0"
@@ -20,6 +21,14 @@ dependencies:
   stack_trace: ^1.4.0
   test: ^0.12.5
   yaml: ^2.1.3
+
+# A note about 'analyzer':
+# We don't actually depend on 'analyzer', but 'test' does. We aren't
+# compatible with some older versions of 'analyzer'. We lie here,
+# saying we do depend on it, so that we constrain the version that
+# 'test' will get to a version that we'll probably be ok with. (This
+# is why there's no upper bound on our dependency.)
+# See also https://github.com/dart-lang/pub/issues/1356
 
 dev_dependencies:
   mockito: "^0.10.1"


### PR DESCRIPTION
...by requiring a new version of analyzer.

Also, when the subprocess is terminated unexpectedly, report the actual
problem in more detail.