### PR TITLE
Enable --no-http by default

### DIFF
--- a/lib/src/artifacts.dart
+++ b/lib/src/artifacts.dart
@@ -38,15 +38,16 @@ String _getNameForTargetPlatform(TargetPlatform platform) {
   }
 }
 
-// Keep in sync with https://github.com/flutter/engine/blob/master/sky/tools/big_red_button.py#L50
+// Keep in sync with https://github.com/flutter/engine/blob/master/sky/tools/release_engine.py
+// and https://github.com/flutter/buildbot/blob/master/travis/build.sh
 String _getCloudStorageBaseUrl({String category, String platform, String revision}) {
-  if (platform == 'darwin-x64') {
+  if (platform == 'android-arm') {
     // In the fullness of time, we'll have a consistent URL pattern for all of
-    // our artifacts, but, for the time being, darwin artifacts are stored in a
+    // our artifacts, but, for the time being, Android artifacts are stored in a
     // different cloud storage bucket.
-    return 'https://storage.googleapis.com/mojo_infra/flutter/${platform}/${revision}/';
+    return 'https://storage.googleapis.com/mojo/sky/${category}/${platform}/${revision}/';
   }
-  return 'https://storage.googleapis.com/mojo/sky/${category}/${platform}/${revision}/';
+  return 'https://storage.googleapis.com/mojo_infra/flutter/${platform}/${revision}/';
 }
 
 enum ArtifactType {

--- a/test/start_test.dart
+++ b/test/start_test.dart
@@ -21,7 +21,7 @@ defineTests() {
       when(mockDevices.android.isConnected()).thenReturn(true);
       when(mockDevices.android.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.android.installApp(any)).thenReturn(true);
-      when(mockDevices.android.startServer(any, any, any, any)).thenReturn(true);
+      when(mockDevices.android.startBundle(any, any, any, any)).thenReturn(true);
       when(mockDevices.android.stopApp(any)).thenReturn(true);
 
       when(mockDevices.iOS.isConnected()).thenReturn(false);
@@ -49,7 +49,7 @@ defineTests() {
       when(mockDevices.android.isConnected()).thenReturn(false);
       when(mockDevices.android.isAppInstalled(any)).thenReturn(false);
       when(mockDevices.android.installApp(any)).thenReturn(false);
-      when(mockDevices.android.startServer(any, any, any, any)).thenReturn(false);
+      when(mockDevices.android.startBundle(any, any, any, any)).thenReturn(false);
       when(mockDevices.android.stopApp(any)).thenReturn(false);
 
       when(mockDevices.iOS.isConnected()).thenReturn(true);


### PR DESCRIPTION
We still have the --http option as a fallback for now. Once we're confident the
--no-http version works, we'll drop the --http support.

Also, create the FLX in a temp directory and then delete the temp directory
when we're done. Finally, pull the Linux artifacts from the cloud storage
bucket that the buildbot is uploading to.